### PR TITLE
Fix running code coverage on Kitura-Session-Redis

### DIFF
--- a/Tests/KituraSessionRedisTests/TestSession.swift
+++ b/Tests/KituraSessionRedisTests/TestSession.swift
@@ -153,11 +153,22 @@ class TestSession : XCTestCase, KituraTest {
     func read(fileName: String) -> String {
         // Read in a configuration file into an NSData
         let fileData: Data
+        
+        let sourceFileName = NSString(string: #file)
+        let pathToTestsPrefixRange: NSRange
+        let lastSlash = sourceFileName.range(of: "/", options: .backwards)
+        if  lastSlash.location != NSNotFound {
+            pathToTestsPrefixRange = NSMakeRange(0, lastSlash.location+1)
+        } else {
+            pathToTestsPrefixRange = NSMakeRange(0, sourceFileName.length)
+        }
+        let pathToTests = sourceFileName.substring(with: pathToTestsPrefixRange)
+        
         do {
-            fileData = try Data(contentsOf: URL(fileURLWithPath: "Tests/KituraSessionRedisTests/\(fileName)"))
+            fileData = try Data(contentsOf: URL(fileURLWithPath: "\(pathToTests)\(fileName)"))
         }
         catch {
-            XCTFail("Failed to read in the \(fileName) file")
+            XCTFail("Failed to read in the \(fileName) file [\(pathToTests)\(fileName)]")
             exit(1)
         }
         


### PR DESCRIPTION
Currently the code coverage build fails for Kitura-Session-Redis. This failure occurs because the code assumes that it is running from with the repository and tries to read in several files in a relative to the repository fashion.

When running in the code coverage build, or just under XCode, the code is not executing from with the repository. this PR corrects this problem by using the source file location to find files to read in during tests.

Tested this by running the Kitura-Session-Redis unit tests under XCode.