### PR TITLE
Eliminated the warning about interpolating a String

### DIFF
--- a/Tests/KituraSessionRedisTests/TestSession.swift
+++ b/Tests/KituraSessionRedisTests/TestSession.swift
@@ -74,7 +74,7 @@ class TestSession : XCTestCase, KituraTest {
                             guard (body != nil) else {
                                 return
                             }
-                            XCTAssertEqual(body!, sessionTestValue, "Body \(body) is not equal to \(sessionTestValue)")
+                            XCTAssertEqual(body!, sessionTestValue, "Body \(String(describing: body)) is not equal to \(sessionTestValue)")
                         }
                         catch{
                             XCTFail("No response body")


### PR DESCRIPTION
Get ready for Swift 3.1 by eliminating the warning about interpolating a String.