### PR TITLE
Enable testing under Ubuntu 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
       env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
-  - git clone https://github.com/IBM-Swift/Kitura-CI.git -b sessionredis-1804
+  - git clone https://github.com/IBM-Swift/Kitura-CI.git
   - git clone https://github.com/IBM-Swift/Package-Builder.git
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ matrix:
       sudo: required
       services: docker
       env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
-#    - os: linux
-#      dist: trusty
-#      sudo: required
-#      services: docker
-#      env: DOCKER_IMAGE=ubuntu:18.04
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE=ubuntu:18.04
     - os: osx
       osx_image: xcode9.2
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
       env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
-  - git clone https://github.com/IBM-Swift/Kitura-CI.git
+  - git clone https://github.com/IBM-Swift/Kitura-CI.git -b sessionredis-1804
   - git clone https://github.com/IBM-Swift/Package-Builder.git
 
 script:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I figured out why redis-server was not working when testing on Ubuntu 18.04 under Docker (see IBM-Swift/Kitura-CI#2).  This PR enables 18.04 testing for this repo (see also https://github.com/IBM-Swift/Kitura-redis/pull/71)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
All our repos should be testing on both Ubuntu 16.04 and 18.04. We were unable to turn this on for the Redis repos as CI failed, so they had been commented out.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
